### PR TITLE
Replace call to James2019 with call to James

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '52191279'
+ValidationKey: '52255672'
 AutocreateReadme: yes
 AcceptedWarnings:
 - 'Warning: package .* was built under R version'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'mrvalidation: madrat data preparation for validation purposes'
-version: 2.61.1
-date-released: '2024-09-23'
+version: 2.61.2
+date-released: '2024-10-10'
 abstract: Package contains routines to prepare data for validation exercises.
 authors:
 - family-names: Bodirsky

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: mrvalidation
 Title: madrat data preparation for validation purposes
-Version: 2.61.1
-Date: 2024-09-23
+Version: 2.61.2
+Date: 2024-10-10
 Authors@R: c(
     person("Benjamin Leon", "Bodirsky", , "bodirsky@pik-potsdam.de", role = c("aut", "cre")),
     person("Stephen", "Wirth", role = "aut"),

--- a/R/calcValidSDG1.R
+++ b/R/calcValidSDG1.R
@@ -11,7 +11,7 @@
 calcValidSDG1 <- function(datasource="James") {
   
   if(datasource=="James"){
-    a <- readSource(type="James2019",subtype="IHME_USD05_PPP_pc")
+    a <- readSource(type="James",subtype="IHME_USD05_PPP_pc")
     pop_weights  <- readSource("WDI",subtype = "SP.POP.TOTL") + 10^-10
     com_years<-intersect(getYears(a),getYears(pop_weights))
     

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # madrat data preparation for validation purposes
 
-R package **mrvalidation**, version **2.61.1**
+R package **mrvalidation**, version **2.61.2**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/mrvalidation)](https://cran.r-project.org/package=mrvalidation) [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.4317826.svg)](https://doi.org/10.5281/zenodo.4317826) [![R build status](https://github.com/pik-piam/mrvalidation/workflows/check/badge.svg)](https://github.com/pik-piam/mrvalidation/actions) [![codecov](https://codecov.io/gh/pik-piam/mrvalidation/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/mrvalidation) [![r-universe](https://pik-piam.r-universe.dev/badges/mrvalidation)](https://pik-piam.r-universe.dev/builds)
 
@@ -39,7 +39,7 @@ In case of questions / problems please contact Benjamin Leon Bodirsky <bodirsky@
 
 To cite package **mrvalidation** in publications use:
 
-Bodirsky B, Wirth S, Karstens K, Humpenoeder F, Stevanovic M, Mishra A, Biewald A, Weindl I, Beier F, Chen D, Crawford M, Leip D, Molina Bacca E, Kreidenweis U, W. Yalew A, von Jeetze P, Wang X, Dietrich J, Alves M (2024). _mrvalidation: madrat data preparation for validation purposes_. doi: 10.5281/zenodo.4317826 (URL: https://doi.org/10.5281/zenodo.4317826), R package version 2.61.1, <URL: https://github.com/pik-piam/mrvalidation>.
+Bodirsky B, Wirth S, Karstens K, Humpenoeder F, Stevanovic M, Mishra A, Biewald A, Weindl I, Beier F, Chen D, Crawford M, Leip D, Molina Bacca E, Kreidenweis U, W. Yalew A, von Jeetze P, Wang X, Dietrich J, Alves M (2024). _mrvalidation: madrat data preparation for validation purposes_. doi:10.5281/zenodo.4317826 <https://doi.org/10.5281/zenodo.4317826>, R package version 2.61.2, <https://github.com/pik-piam/mrvalidation>.
 
 A BibTeX entry for LaTeX users is
 
@@ -48,7 +48,7 @@ A BibTeX entry for LaTeX users is
   title = {mrvalidation: madrat data preparation for validation purposes},
   author = {Benjamin Leon Bodirsky and Stephen Wirth and Kristine Karstens and Florian Humpenoeder and Mishko Stevanovic and Abhijeet Mishra and Anne Biewald and Isabelle Weindl and Felicitas Beier and David Chen and Michael Crawford and Debbora Leip and Edna {Molina Bacca} and Ulrich Kreidenweis and Amsalu {W. Yalew} and Patrick {von Jeetze} and Xiaoxi Wang and Jan Philipp Dietrich and Marcos Alves},
   year = {2024},
-  note = {R package version 2.61.1},
+  note = {R package version 2.61.2},
   doi = {10.5281/zenodo.4317826},
   url = {https://github.com/pik-piam/mrvalidation},
 }


### PR DESCRIPTION
The James2019 dataset has no reference. Use the James dataset instead. (Also, the James2019 dataset will be removed from mrdrivers in the next mrdrivers update).