### PR TITLE
Yield reporting rename

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '55784700'
+ValidationKey: '56040090'
 AutocreateReadme: yes
 AcceptedWarnings:
 - 'Warning: package .* was built under R version'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'mrvalidation: madrat data preparation for validation purposes'
-version: 2.70.0
-date-released: '2026-07-27'
+version: 2.71.0
+date-released: '2026-08-14'
 abstract: Package contains routines to prepare data for validation exercises.
 authors:
 - family-names: Bodirsky

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -64,4 +64,4 @@ Encoding: UTF-8
 LazyData: no
 Config/Needs/website: tidyverse/tidytemplate
 Config/roxygen2/version: 8.0.0
-RoxygenNote: 7.3.2
+RoxygenNote: 7.3.3

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: mrvalidation
 Title: madrat data preparation for validation purposes
-Version: 2.70.0
-Date: 2026-07-27
+Version: 2.71.0
+Date: 2026-08-14
 Authors@R: c(
     person("Benjamin Leon", "Bodirsky", , "bodirsky@pik-potsdam.de", role = c("aut", "cre")),
     person("Stephen", "Wirth", role = "aut"),
@@ -64,3 +64,4 @@ Encoding: UTF-8
 LazyData: no
 Config/Needs/website: tidyverse/tidytemplate
 Config/roxygen2/version: 8.0.0
+RoxygenNote: 7.3.2

--- a/R/calcValidTau.R
+++ b/R/calcValidTau.R
@@ -45,7 +45,8 @@ calcValidTau <- function(datasource = "FAO2012") {
     description <- "Historic Trends in Agricultural Land Use Intensity Tau based on FAO yield trends (updated)"
     sourceName <- "dietrich_et_al_2012_updated"
   } else if (datasource == "FAOValidYields") {
-    cropYields <- calcOutput("ValidYield", aggregate = FALSE)[, , "historical.FAO.Productivity|Yield|+|Crops (t DM/ha)"]
+    cropYields <- calcOutput("ValidYield", aggregate = FALSE)[
+      , , "historical.FAO.Productivity|Yields|Yield by physical area|+|Crops (t DM/ha)"]
     yieldIndex <- collapseDim(cropYields / cropYields[, 1995, ])
 
     # average growth rates of more than 20% per year are assumed to be incorrect

--- a/R/calcValidTau.R
+++ b/R/calcValidTau.R
@@ -45,7 +45,7 @@ calcValidTau <- function(datasource = "FAO2012") {
     description <- "Historic Trends in Agricultural Land Use Intensity Tau based on FAO yield trends (updated)"
     sourceName <- "dietrich_et_al_2012_updated"
   } else if (datasource == "FAOValidYields") {
-    cropYieldVar <- "historical.FAO.Productivity|Yields|Yield by physical area|+|Crops (t DM/ha)"
+    cropYieldVar <- "historical.FAO.Productivity|Yields|Yield by physical area|Crops (t DM/ha)"
     cropYields <- calcOutput("ValidYield", aggregate = FALSE)[, , cropYieldVar]
     yieldIndex <- collapseDim(cropYields / cropYields[, 1995, ])
 

--- a/R/calcValidTau.R
+++ b/R/calcValidTau.R
@@ -45,8 +45,8 @@ calcValidTau <- function(datasource = "FAO2012") {
     description <- "Historic Trends in Agricultural Land Use Intensity Tau based on FAO yield trends (updated)"
     sourceName <- "dietrich_et_al_2012_updated"
   } else if (datasource == "FAOValidYields") {
-    cropYields <- calcOutput("ValidYield", aggregate = FALSE)[
-      , , "historical.FAO.Productivity|Yields|Yield by physical area|+|Crops (t DM/ha)"]
+    cropYieldVar <- "historical.FAO.Productivity|Yields|Yield by physical area|+|Crops (t DM/ha)"
+    cropYields <- calcOutput("ValidYield", aggregate = FALSE)[, , cropYieldVar]
     yieldIndex <- collapseDim(cropYields / cropYields[, 1995, ])
 
     # average growth rates of more than 20% per year are assumed to be incorrect

--- a/R/calcValidYield.R
+++ b/R/calcValidYield.R
@@ -31,10 +31,10 @@
 calcValidYield  <-  function(datasource = "FAO", faoVersion = "join2010", future = NULL, physical = TRUE) {
 
   if (physical) {
-    indicatorName <- "Productivity|Yield"
+    indicatorName <- "Productivity|Yields|Yield by physical area"
     descName <- "physical area"
   } else {
-    indicatorName <- "Productivity|Yield by harvested area"
+    indicatorName <- "Productivity|Yields|Yield by harvested area"
     descName <- "harvested area"
   }
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # madrat data preparation for validation purposes
 
-R package **mrvalidation**, version **2.70.0**
+R package **mrvalidation**, version **2.71.0**
 
   [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.4317826.svg)](https://doi.org/10.5281/zenodo.4317826) [![R build status](https://github.com/pik-piam/mrvalidation/workflows/check/badge.svg)](https://github.com/pik-piam/mrvalidation/actions) [![codecov](https://codecov.io/gh/pik-piam/mrvalidation/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/mrvalidation) [![r-universe](https://pik-piam.r-universe.dev/badges/mrvalidation)](https://pik-piam.r-universe.dev/builds)
 
@@ -39,7 +39,7 @@ In case of questions / problems please contact Benjamin Leon Bodirsky <bodirsky@
 
 To cite package **mrvalidation** in publications use:
 
-Bodirsky B, Wirth S, Karstens K, Humpenoeder F, Stevanovic M, Mishra A, Biewald A, Weindl I, Beier F, Chen D, Crawford M, Leip D, Molina Bacca E, Kreidenweis U, W. Yalew A, von Jeetze P, Wang X, Dietrich J, Alves M (2026). "mrvalidation: madrat data preparation for validation purposes." doi:10.5281/zenodo.4317826 <https://doi.org/10.5281/zenodo.4317826>, Version: 2.70.0, <https://github.com/pik-piam/mrvalidation>.
+Bodirsky B, Wirth S, Karstens K, Humpenoeder F, Stevanovic M, Mishra A, Biewald A, Weindl I, Beier F, Chen D, Crawford M, Leip D, Molina Bacca E, Kreidenweis U, W. Yalew A, von Jeetze P, Wang X, Dietrich J, Alves M (2026). "mrvalidation: madrat data preparation for validation purposes." doi:10.5281/zenodo.4317826 <https://doi.org/10.5281/zenodo.4317826>, Version: 2.71.0, <https://github.com/pik-piam/mrvalidation>.
 
 A BibTeX entry for LaTeX users is
 
@@ -48,9 +48,9 @@ A BibTeX entry for LaTeX users is
   title = {mrvalidation: madrat data preparation for validation purposes},
   author = {Benjamin Leon Bodirsky and Stephen Wirth and Kristine Karstens and Florian Humpenoeder and Mishko Stevanovic and Abhijeet Mishra and Anne Biewald and Isabelle Weindl and Felicitas Beier and David Chen and Michael Crawford and Debbora Leip and Edna {Molina Bacca} and Ulrich Kreidenweis and Amsalu {W. Yalew} and Patrick {von Jeetze} and Xiaoxi Wang and Jan Philipp Dietrich and Marcos Alves},
   doi = {10.5281/zenodo.4317826},
-  date = {2026-07-27},
+  date = {2026-08-14},
   year = {2026},
   url = {https://github.com/pik-piam/mrvalidation},
-  note = {Version: 2.70.0},
+  note = {Version: 2.71.0},
 }
 ```

--- a/man/mrvalidation-package.Rd
+++ b/man/mrvalidation-package.Rd
@@ -22,7 +22,6 @@ Useful links:
 
 Authors:
 \itemize{
-  \item Benjamin Leon Bodirsky \email{bodirsky@pik-potsdam.de}
   \item Stephen Wirth
   \item Kristine Karstens
   \item Florian Humpenoeder


### PR DESCRIPTION
Companion to pik-piam/magpie4#<N>, which restructures the yield reporting variables.

| old | new |
|---|---|
| `Productivity\|Yield` | `Productivity\|Yields\|Yield by physical area` |
| `Productivity\|Yield by harvested area` | `Productivity\|Yields\|Yield by harvested area` |

**This repo has to move in the same window as magpie4.** Validation figures overlay the
historical reference onto model output by matching variable names. If magpie4 renames and
mrvalidation does not, every yield validation panel loses its history and renders empty, with
no error anywhere.

### Also revives the `FAOValidYields` path (dead since 2024-02-26)

That selector carried a `|+|` summation marker and had matched nothing since **2024-02-26**,
when `7a67f9e` added `sep = NULL` at all four `calcValidYield` call sites and stripped the
markers. The rename alone would have carried the dead marker into the new name, so the marker
is dropped here too:

    - historical.FAO.Productivity|Yields|Yield by physical area|+|Crops (t DM/ha)
    + historical.FAO.Productivity|Yields|Yield by physical area|Crops (t DM/ha)

This is a behaviour change (dead → live) rather than a rename, so it is called out separately.
**No shipped number moves:** `FAOValidYields` is referenced nowhere but its own `else if`
branch, and `fullVALIDATION.R:319` calls `ValidTau` with no `datasource`, i.e. the default
path. Verified under madrat against the real source data: `ValidTau(FAOValidYields)` returns
249 countries x 12 years (1965..2020), range 0 .. 4.4492, no NAs. Before the fix it raised
`subscript out of bounds` on both this branch and `master`.
